### PR TITLE
npm publish from release

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -45,7 +45,13 @@ jobs:
       - name: npm install
         run: npm install
 
+      - name: npm login
+        run: |
+          npm config set //registry.npmjs.org/:_authToken ${{secrets.NPM_TOKEN}}
+          npm publish --ignore-scripts
+
+
       - name: publish to npm
-        run: npm publish . --tag ${{steps.get_package_json.outputs.prop}}@${{steps.get_package_version.outputs.prop}}
+        run: npm publish . --tag ${{steps.get_package_json.outputs.prop}}@${{steps.get_package_version.outputs.prop}} --ignore-scripts
         env:
           NPM_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,51 @@
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: setup node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16
+
+      - name: get version from tag
+        id: get_version
+        run: |
+            realversion="${GITHUB_REF/refs\/tags\//}"
+            realversion="${realversion//v/}"
+            echo "::set-output name=VERSION::$realversion"
+
+      - name: Set version from tag
+        uses: jossef/action-set-json-field@v1
+        with:
+          file: package.json
+          field: version
+          value: ${{steps.get_version.outputs.VERSION}}
+
+      - name: Read project name
+        uses: notiz-dev/github-action-json-property@release
+        id: get_package_json
+        with:
+          path: package.json
+          prop_path: name
+
+      - name: Read project version
+        uses: notiz-dev/github-action-json-property@release
+        id: get_package_version
+        with:
+          path: package.json
+          prop_path: version
+
+      - name: npm install
+        run: npm install
+
+      - name: publish to npm
+        run: npm publish . --tag ${{steps.get_package_json.outputs.prop}}@${{steps.get_package_version.outputs.prop}}
+        env:
+          NPM_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/package.json
+++ b/package.json
@@ -1,4 +1,6 @@
 {
+	"name": "redisgearsmonitor",
+	"version": "0.1.0",
 	"description": "RedisGear registrations simple GUI",
 	"repository": "https://github.com/RedisGears/RedisGearsMonitor",
 	"license": "BSD 3",


### PR DESCRIPTION
If you're curious you can see a dry-run [here](https://github.com/RedisAI/redisai-js/runs/3180302989?check_suite_focus=true), validated with RedisAI.

Not that we release this. But now we can.